### PR TITLE
Pass lazy items to individual composers

### DIFF
--- a/app/src/main/java/com/example/microfeaturecodelab/FeatureScreenViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/FeatureScreenViewModel.kt
@@ -9,6 +9,8 @@ import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfi
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentDependencies
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.FeatureConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,6 +20,7 @@ class FeatureScreenViewModel @Inject constructor(
     private val componentViewModelFactory: ComponentViewModelFactory,
 ) : ViewModel() {
 
+    val state = MutableStateFlow(Widgets(emptyList(), true))
     private lateinit var _components: List<ComponentConfig>
 
     private val _componentDependencyMap = mutableMapOf<String, ComponentDependencies>()
@@ -36,13 +39,20 @@ class FeatureScreenViewModel @Inject constructor(
                     componentViewModelFactory.create(componentConfig, viewModelScope)
                 _componentDependencyMap[componentConfig.id] = componentDependency
             }
+            state.update {
+                Widgets(
+                    items = _components,
+                    isLoading = false
+                )
+            }
         }
     }
 
-    fun getComponents() = Widgets(_components)
+    //fun getComponents() = Widgets(_components)
 }
 
 @Stable
 data class Widgets(
     val items: List<ComponentConfig>,
+    val isLoading: Boolean = false,
 )

--- a/app/src/main/java/com/example/microfeaturecodelab/FeatureScreenViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/FeatureScreenViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.microfeaturecodelab.personalisedjob.presentation
+package com.example.microfeaturecodelab
 
 import android.util.Log
 import androidx.compose.runtime.Stable

--- a/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
@@ -35,7 +35,9 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             MicroFeatureCodelabTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                Scaffold(
+                    modifier = Modifier.fillMaxSize()
+                ) { innerPadding ->
                     SelfDrivenSingleUiComponentsScreen(
                         modifier = Modifier.padding(innerPadding)
                     )
@@ -56,7 +58,7 @@ fun SelfDrivenSingleUiComponentsScreen(
 ) {
     val components by viewModel.state.collectAsStateWithLifecycle()
     ComponentList(
-        items = components,
+        widgets = components,
         componentDependencyMap = viewModel.componentDependencyMap,
         modifier = modifier
     )
@@ -64,11 +66,11 @@ fun SelfDrivenSingleUiComponentsScreen(
 
 @Composable
 fun ComponentList(
-    items: Widgets,
+    widgets: Widgets,
     componentDependencyMap: Map<String, ComponentDependencies>,
     modifier: Modifier = Modifier
 ) {
-    if (items.isLoading) {
+    if (widgets.isLoading) {
         // Show loading state
         LoadingIndicator(modifier = modifier)
         return
@@ -79,7 +81,7 @@ fun ComponentList(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         // Dynamically generate items for components
-        items.items.forEach { component ->
+        widgets.items.forEach { component ->
             val componentDependency = componentDependencyMap[component.id]
             Log.d("MicroFeature", "ComponentList:index ${component.id}")
             componentDependency?.let {

--- a/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
@@ -23,8 +23,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentDependencies
+import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ItemType
 import com.example.microfeaturecodelab.ui.theme.MicroFeatureCodelabTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -75,6 +77,7 @@ fun ComponentList(
         LoadingIndicator(modifier = modifier)
         return
     }
+    val lifecycle = LocalLifecycleOwner.current
     LazyColumn(
         modifier = modifier,
         contentPadding = PaddingValues(16.dp),
@@ -89,6 +92,7 @@ fun ComponentList(
                     viewModel = componentDependency.componentVM,
                     config = component,
                     scope = this,
+                    lifecycle = lifecycle,
                     modifier = Modifier.fillMaxWidth(),
                     onAction = {}
                 )

--- a/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
@@ -88,14 +88,18 @@ fun ComponentList(
             val componentDependency = componentDependencyMap[component.id]
             Log.d("MicroFeature", "ComponentList:index ${component.id}")
             componentDependency?.let {
-                componentDependency.componentComposer.renderItem(
-                    viewModel = componentDependency.componentVM,
-                    config = component,
-                    scope = this,
-                    lifecycle = lifecycle,
-                    modifier = Modifier.fillMaxWidth(),
-                    onAction = {}
-                )
+
+                // FIXME: This is a temporary fix to avoid rendering the list component
+                if (component.itemType != ItemType.LIST) {
+                    componentDependency.componentComposer.renderItem(
+                        viewModel = componentDependency.componentVM,
+                        config = component,
+                        scope = this,
+                        lifecycle = lifecycle,
+                        modifier = Modifier.fillMaxWidth(),
+                        onAction = {}
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
@@ -6,20 +6,24 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentDependencies
 import com.example.microfeaturecodelab.ui.theme.MicroFeatureCodelabTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,7 +54,7 @@ fun SelfDrivenSingleUiComponentsScreen(
     modifier: Modifier = Modifier,
     viewModel: FeatureScreenViewModel = hiltViewModel()
 ) {
-    val components by remember { mutableStateOf(viewModel.getComponents()) }
+    val components by viewModel.state.collectAsStateWithLifecycle()
     ComponentList(
         items = components,
         componentDependencyMap = viewModel.componentDependencyMap,
@@ -64,6 +68,11 @@ fun ComponentList(
     componentDependencyMap: Map<String, ComponentDependencies>,
     modifier: Modifier = Modifier
 ) {
+    if (items.isLoading) {
+        // Show loading state
+        LoadingIndicator(modifier = modifier)
+        return
+    }
     LazyColumn(
         modifier = modifier,
         contentPadding = PaddingValues(16.dp),
@@ -83,6 +92,20 @@ fun ComponentList(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun LoadingIndicator(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize(), // Fills the entire screen
+        contentAlignment = Alignment.Center // Centers the content
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(80.dp), // Size of the loader
+            color = MaterialTheme.colorScheme.tertiary // Loader color
+        )
     }
 }
 

--- a/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentDependencies
 import com.example.microfeaturecodelab.ui.theme.MicroFeatureCodelabTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -72,7 +70,7 @@ fun ComponentList(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         // Dynamically generate items for components
-        items.items.map { component ->
+        items.items.forEach { component ->
             val componentDependency = componentDependencyMap[component.id]
             Log.d("MicroFeature", "ComponentList:index ${component.id}")
             componentDependency?.let {
@@ -85,35 +83,8 @@ fun ComponentList(
                 )
             }
         }
-        /*items(
-            items = items.items,
-            key = { it.id },
-            itemContent = { component ->
-                val componentDependency = remember(items) {
-                    componentDependencyMap[component.id]
-                }
-                Log.d("MicroFeature", "ComponentList:index ${component.id}")
-                componentDependency?.let {
-                    ComponentItem(component, componentDependency)
-                }
-            }
-        )*/
     }
 }
-
-//@Composable
-//fun ComponentItem(
-//    component: ComponentConfig,
-//    componentDependency: ComponentDependencies,
-//) {
-//    Log.d("MicroFeature", "ComponentItem: ${component.id} vm:${componentDependency.componentVM}")
-//    componentDependency.componentComposer.ComposerContent(
-//        viewModel = componentDependency.componentVM,
-//        config = component,
-//        modifier = Modifier.fillMaxWidth(),
-//        onAction = {}
-//    )
-//}
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/MainActivity.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.microfeaturecodelab.personalisedjob.presentation.FeatureScreenViewModel
-import com.example.microfeaturecodelab.personalisedjob.presentation.Widgets
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentDependencies
 import com.example.microfeaturecodelab.ui.theme.MicroFeatureCodelabTheme
@@ -74,7 +72,20 @@ fun ComponentList(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         // Dynamically generate items for components
-        items(
+        items.items.map { component ->
+            val componentDependency = componentDependencyMap[component.id]
+            Log.d("MicroFeature", "ComponentList:index ${component.id}")
+            componentDependency?.let {
+                componentDependency.componentComposer.renderItem(
+                    viewModel = componentDependency.componentVM,
+                    config = component,
+                    scope = this,
+                    modifier = Modifier.fillMaxWidth(),
+                    onAction = {}
+                )
+            }
+        }
+        /*items(
             items = items.items,
             key = { it.id },
             itemContent = { component ->
@@ -86,23 +97,23 @@ fun ComponentList(
                     ComponentItem(component, componentDependency)
                 }
             }
-        )
+        )*/
     }
 }
 
-@Composable
-fun ComponentItem(
-    component: ComponentConfig,
-    componentDependency: ComponentDependencies,
-) {
-    Log.d("MicroFeature", "ComponentItem: ${component.id} vm:${componentDependency.componentVM}")
-    componentDependency.componentComposer.ComposerContent(
-        viewModel = componentDependency.componentVM,
-        config = component,
-        modifier = Modifier.fillMaxWidth(),
-        onAction = {}
-    )
-}
+//@Composable
+//fun ComponentItem(
+//    component: ComponentConfig,
+//    componentDependency: ComponentDependencies,
+//) {
+//    Log.d("MicroFeature", "ComponentItem: ${component.id} vm:${componentDependency.componentVM}")
+//    componentDependency.componentComposer.ComposerContent(
+//        viewModel = componentDependency.componentVM,
+//        config = component,
+//        modifier = Modifier.fillMaxWidth(),
+//        onAction = {}
+//    )
+//}
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/example/microfeaturecodelab/base/AbstractMicroFeatureComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/base/AbstractMicroFeatureComposer.kt
@@ -2,28 +2,33 @@ package com.example.microfeaturecodelab.base
 
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.LifecycleOwner
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
 
+@Suppress("UNCHECKED_CAST")
 abstract class AbstractMicroFeatureComposer<V : MicroFeatureViewModel> {
 
     fun renderItem(
         viewModel: MicroFeatureViewModel,
         config: ComponentConfig,
         scope: LazyListScope,
+        lifecycle: LifecycleOwner,
         modifier: Modifier,
         onAction: (Any) -> Unit,
     ) {
         scope.content(
             viewModel = viewModel as V,
             config = config,
+            lifecycle = lifecycle,
             modifier = modifier,
-            onAction = onAction
+            onAction = onAction,
         )
     }
 
     abstract fun LazyListScope.content(
         viewModel: V,
         config: ComponentConfig,
+        lifecycle: LifecycleOwner,
         modifier: Modifier = Modifier,
         onAction: (Any) -> Unit,
     )

--- a/app/src/main/java/com/example/microfeaturecodelab/base/AbstractMicroFeatureComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/base/AbstractMicroFeatureComposer.kt
@@ -1,19 +1,19 @@
 package com.example.microfeaturecodelab.base
 
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
 
 abstract class AbstractMicroFeatureComposer<V : MicroFeatureViewModel> {
 
-    @Composable
-    fun ComposerContent(
+    fun renderItem(
         viewModel: MicroFeatureViewModel,
         config: ComponentConfig,
+        scope: LazyListScope,
         modifier: Modifier,
         onAction: (Any) -> Unit,
     ) {
-        Content(
+        scope.content(
             viewModel = viewModel as V,
             config = config,
             modifier = modifier,
@@ -21,8 +21,7 @@ abstract class AbstractMicroFeatureComposer<V : MicroFeatureViewModel> {
         )
     }
 
-    @Composable
-    abstract fun Content(
+    abstract fun LazyListScope.content(
         viewModel: V,
         config: ComponentConfig,
         modifier: Modifier = Modifier,

--- a/app/src/main/java/com/example/microfeaturecodelab/base/ComponentViewModelFactory.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/base/ComponentViewModelFactory.kt
@@ -15,7 +15,7 @@ class ComponentViewModelFactory @Inject constructor(
         viewModelScope: CoroutineScope
     ): ComponentDependencies {
         return viewModelFactories[componentConfig.type]?.let {
-            val componentVM = viewModelFactories[componentConfig.type]?.create(viewModelScope)
+            val componentVM = viewModelFactories[componentConfig.type]?.create(viewModelScope, componentConfig.fetchStrategy)
             val componentComposer = composerFactories[componentConfig.type]
             if (componentVM != null && componentComposer != null) {
                 ComponentDependencies(componentVM, componentComposer)

--- a/app/src/main/java/com/example/microfeaturecodelab/base/MicroFeatureFactory.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/base/MicroFeatureFactory.kt
@@ -1,7 +1,11 @@
 package com.example.microfeaturecodelab.base
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
 
 interface MicroFeatureFactory<T> {
-    fun create(coroutineScope: CoroutineScope): T
+    fun create(
+        coroutineScope: CoroutineScope,
+        fetchStrategy: SharingStarted
+    ): T
 }

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/composables/JobRecommendationComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/composables/JobRecommendationComposer.kt
@@ -2,6 +2,7 @@ package com.example.microfeaturecodelab.personalisedjob.presentation.composables
 
 import android.util.Log
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -21,14 +22,16 @@ import javax.inject.Inject
 
 class JobRecommendationComposer @Inject constructor() :
     AbstractMicroFeatureComposer<PersonalisedJobViewModel>() {
-    @Composable
-    override fun Content(
+
+    override fun LazyListScope.content(
         viewModel: PersonalisedJobViewModel,
         config: ComponentConfig,
         modifier: Modifier,
         onAction: (Any) -> Unit
     ) {
-        JobRecommendation(viewmodel = viewModel, id = config.id, modifier = modifier)
+        item(config.id) {
+            JobRecommendation(viewmodel = viewModel, id = config.id, modifier = modifier)
+        }
     }
 
     @Composable
@@ -75,5 +78,4 @@ class JobRecommendationComposer @Inject constructor() :
             }
         }
     }
-
 }

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/composables/JobRecommendationComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/composables/JobRecommendationComposer.kt
@@ -1,6 +1,7 @@
 package com.example.microfeaturecodelab.personalisedjob.presentation.composables
 
 import android.util.Log
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,7 +43,8 @@ class JobRecommendationComposer @Inject constructor() :
     ) {
         Log.d("MicroFeature", "JobRecommendationComposer: Recomposing ${viewmodel.hashCode()}")
         // This collect triggers the flow in the viewmodel to fetch data from use case
-        // @TODO Currently its being called for all 20 items in lazy column which is inefficient
+        // @TODO ISSUE #1
+        // Currently its being called for all 20 items in lazy column which is inefficient
 
         // Uncomment this to see the issue, with sealed state
 //        val personalisedJob by viewmodel.uiState.collectAsStateWithLifecycle()
@@ -65,16 +67,20 @@ class JobRecommendationComposer @Inject constructor() :
             Log.d("JobRecommendationSection", "$id Launched Effect")
         }
         Card(
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            shape = RoundedCornerShape(8.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
             modifier = modifier
-                .padding(32.dp),
+                .padding(vertical = 4.dp),
         ) {
-            Text("Item $id")
-            Text(state.sectionTitle)
+            Column(Modifier.padding(12.dp)) {
+                Text(
+                    "Item $id",
+                    style = MaterialTheme.typography.headlineSmall
+                )
 
-            state.items.map {
-                Text(it.jobTitle)
+                state.items.map {
+                    Text(it.jobTitle, style = MaterialTheme.typography.bodyMedium)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/composables/JobRecommendationComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/composables/JobRecommendationComposer.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
@@ -27,8 +28,9 @@ class JobRecommendationComposer @Inject constructor() :
     override fun LazyListScope.content(
         viewModel: PersonalisedJobViewModel,
         config: ComponentConfig,
+        lifecycle: LifecycleOwner,
         modifier: Modifier,
-        onAction: (Any) -> Unit
+        onAction: (Any) -> Unit,
     ) {
         item(config.id) {
             JobRecommendation(viewmodel = viewModel, id = config.id, modifier = modifier)

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/ComponentConfig.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/ComponentConfig.kt
@@ -7,8 +7,15 @@ import com.example.microfeaturecodelab.base.MicroFeatureViewModel
 @Stable
 data class ComponentConfig(
     val id: String,
-    val type: String
+    val type: String,
+    val itemType: ItemType = ItemType.ITEM
 )
+
+enum class ItemType {
+    ITEM,
+    LIST,
+    STICKY
+}
 
 @Stable
 data class ComponentDependencies(

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/ComponentConfig.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/ComponentConfig.kt
@@ -3,12 +3,14 @@ package com.example.microfeaturecodelab.personalisedjob.presentation.featureconf
 import androidx.compose.runtime.Stable
 import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
 import com.example.microfeaturecodelab.base.MicroFeatureViewModel
+import kotlinx.coroutines.flow.SharingStarted
 
 @Stable
 data class ComponentConfig(
     val id: String,
     val type: String,
-    val itemType: ItemType = ItemType.ITEM
+    val itemType: ItemType = ItemType.ITEM,
+    val fetchStrategy: SharingStarted = FetchStrategy.Lazy().sharingStarted,
 )
 
 enum class ItemType {
@@ -22,3 +24,13 @@ data class ComponentDependencies(
     val componentVM: MicroFeatureViewModel,
     val componentComposer: AbstractMicroFeatureComposer<out MicroFeatureViewModel>
 )
+
+sealed class FetchStrategy {
+    data class Lazy(
+        val sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(
+            5000
+        )
+    ) : FetchStrategy()
+
+    data class Eager(val sharingStarted: SharingStarted = SharingStarted.Eagerly) : FetchStrategy()
+}

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/FakeFeatureConfigImpl.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/FakeFeatureConfigImpl.kt
@@ -3,6 +3,14 @@ package com.example.microfeaturecodelab.personalisedjob.presentation.featureconf
 import javax.inject.Inject
 
 class FakeFeatureConfigImpl @Inject constructor(): FeatureConfig {
+
+    /*
+    * North Star
+    * The component list can be retrieved from server which can contain following:
+    * 1. type of component
+    * 2. static data required to render the component
+    * 3. input/endpoint to fetch the data (use endpoint mapper to map the input to the actual endpoint)
+    * */
     override suspend fun getComponentsConfig(): List<ComponentConfig> {
         val type1List =  (1..20).map {
             ComponentConfig(it.toString(), "personalisedJob")

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/FakeFeatureConfigImpl.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/FakeFeatureConfigImpl.kt
@@ -23,14 +23,15 @@ class FakeFeatureConfigImpl @Inject constructor(
         return withContext(ioDispatcher) {
             Log.d("MicroFeature", "Fetching widgets ")
             delay(2000)
-            val type1List =  (1..20).map {
+            val type1List =  (1..5).map {
                 ComponentConfig(it.toString(), "personalisedJob")
             }
-            val type2List = (25..30).map {
+            val type2List = (6..10).map {
                 ComponentConfig(it.toString(), "premiumApplicant")
             }
+            val type3List = ComponentConfig("11", "recentSearches", ItemType.LIST)
             Log.d("MicroFeature", "Fetched widgets ")
-            type1List + type2List
+            type1List + type2List + type3List
         }
     }
 }

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/FakeFeatureConfigImpl.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/featureconfig/FakeFeatureConfigImpl.kt
@@ -1,8 +1,16 @@
 package com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig
 
+import android.util.Log
+import com.example.microfeaturecodelab.di.AppDispatchers
+import com.example.microfeaturecodelab.di.Dispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class FakeFeatureConfigImpl @Inject constructor(): FeatureConfig {
+class FakeFeatureConfigImpl @Inject constructor(
+    @Dispatcher(AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher
+): FeatureConfig {
 
     /*
     * North Star
@@ -12,12 +20,17 @@ class FakeFeatureConfigImpl @Inject constructor(): FeatureConfig {
     * 3. input/endpoint to fetch the data (use endpoint mapper to map the input to the actual endpoint)
     * */
     override suspend fun getComponentsConfig(): List<ComponentConfig> {
-        val type1List =  (1..20).map {
-            ComponentConfig(it.toString(), "personalisedJob")
+        return withContext(ioDispatcher) {
+            Log.d("MicroFeature", "Fetching widgets ")
+            delay(2000)
+            val type1List =  (1..20).map {
+                ComponentConfig(it.toString(), "personalisedJob")
+            }
+            val type2List = (25..30).map {
+                ComponentConfig(it.toString(), "premiumApplicant")
+            }
+            Log.d("MicroFeature", "Fetched widgets ")
+            type1List + type2List
         }
-        val type2List = (25..30).map {
-            ComponentConfig(it.toString(), "premiumApplicant")
-        }
-        return type1List + type2List
     }
 }

--- a/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/uimodel/PersonalisedJobViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/personalisedjob/presentation/uimodel/PersonalisedJobViewModel.kt
@@ -5,6 +5,7 @@ import com.example.microfeaturecodelab.base.MicroFeatureFactory
 import com.example.microfeaturecodelab.base.MicroFeatureViewModel
 import com.example.microfeaturecodelab.personalisedjob.domain.JobQueryParameter
 import com.example.microfeaturecodelab.personalisedjob.domain.GetJobsUseCase
+import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.FetchStrategy
 import com.example.microfeaturecodelab.personalisedjob.presentation.model.RecommendedJobSection
 import com.example.microfeaturecodelab.personalisedjob.presentation.model.toUiModel
 import dagger.assisted.Assisted
@@ -25,7 +26,8 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalCoroutinesApi::class)
 class PersonalisedJobViewModel @AssistedInject constructor(
     private val useCase: GetJobsUseCase,
-    @Assisted val coroutineScope: CoroutineScope
+    @Assisted val coroutineScope: CoroutineScope,
+    @Assisted val sharingStarted: SharingStarted
 ): MicroFeatureViewModel {
     private val inputFlow = MutableStateFlow(JobQueryParameter.DEFAULT)
 
@@ -52,7 +54,7 @@ class PersonalisedJobViewModel @AssistedInject constructor(
         }
     }.stateIn(
         scope = coroutineScope,
-        started = SharingStarted.WhileSubscribed(5000L),
+        started = sharingStarted,
         initialValue = RecommendedJobSection("Loading", emptyList())
     )
 

--- a/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
@@ -29,7 +29,7 @@ class PremiumApplicantComposer @Inject constructor() :
         item {
             Log.d("PremiumApplicantComposer", "PremiumApplicantComposer: ${config.id}")
             LaunchedEffect(viewModel) {
-                Log.d("JobRecommendationSection", "$viewModel Launched Effect")
+                Log.d("JobRecommendationSection", "Launched Effect")
             }
             Card(
                 shape = RoundedCornerShape(8.dp),

--- a/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
@@ -2,6 +2,7 @@ package com.example.microfeaturecodelab.premiumApplicant.presentation
 
 import android.util.Log
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -15,27 +16,29 @@ import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
 import javax.inject.Inject
 
-class PremiumApplicantComposer @Inject constructor(): AbstractMicroFeatureComposer<PremiumApplicantViewModel>() {
-    @Composable
-    override fun Content(
+class PremiumApplicantComposer @Inject constructor() :
+    AbstractMicroFeatureComposer<PremiumApplicantViewModel>() {
+    override fun LazyListScope.content(
         viewModel: PremiumApplicantViewModel,
         config: ComponentConfig,
         modifier: Modifier,
         onAction: (Any) -> Unit
     ) {
-        Log.d("PremiumApplicantComposer", "PremiumApplicantComposer: ${config.id}")
-        LaunchedEffect(viewModel) {
-            Log.d("JobRecommendationSection", "$viewModel Launched Effect")
-        }
-        Card(
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-            modifier = modifier
-                .padding(32.dp),
-        ) {
-            Text("Item ${config.id}")
-            Text("Premium applicant")
+        item {
+            Log.d("PremiumApplicantComposer", "PremiumApplicantComposer: ${config.id}")
+            LaunchedEffect(viewModel) {
+                Log.d("JobRecommendationSection", "$viewModel Launched Effect")
+            }
+            Card(
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                modifier = modifier
+                    .padding(32.dp),
+            ) {
+                Text("Item ${config.id}")
+                Text("Premium applicant")
 
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.LifecycleOwner
 import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
 import javax.inject.Inject
@@ -21,8 +22,9 @@ class PremiumApplicantComposer @Inject constructor() :
     override fun LazyListScope.content(
         viewModel: PremiumApplicantViewModel,
         config: ComponentConfig,
+        lifecycle: LifecycleOwner,
         modifier: Modifier,
-        onAction: (Any) -> Unit
+        onAction: (Any) -> Unit,
     ) {
         item {
             Log.d("PremiumApplicantComposer", "PremiumApplicantComposer: ${config.id}")

--- a/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantComposer.kt
@@ -1,6 +1,7 @@
 package com.example.microfeaturecodelab.premiumApplicant.presentation
 
 import android.util.Log
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -8,7 +9,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -30,14 +30,14 @@ class PremiumApplicantComposer @Inject constructor() :
                 Log.d("JobRecommendationSection", "$viewModel Launched Effect")
             }
             Card(
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                modifier = modifier
-                    .padding(32.dp),
+                shape = RoundedCornerShape(8.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                modifier = modifier.padding(vertical = 4.dp),
             ) {
-                Text("Item ${config.id}")
-                Text("Premium applicant")
-
+                Column(Modifier.padding(12.dp)) {
+                    Text("Item ${config.id}", style = MaterialTheme.typography.headlineSmall)
+                    Text("Premium applicant", style = MaterialTheme.typography.bodySmall)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/premiumApplicant/presentation/PremiumApplicantViewModel.kt
@@ -2,13 +2,16 @@ package com.example.microfeaturecodelab.premiumApplicant.presentation
 
 import com.example.microfeaturecodelab.base.MicroFeatureFactory
 import com.example.microfeaturecodelab.base.MicroFeatureViewModel
+import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.FetchStrategy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
 
 class PremiumApplicantViewModel @AssistedInject constructor(
-    @Assisted val coroutineScope: CoroutineScope
+    @Assisted val coroutineScope: CoroutineScope,
+    @Assisted val sharingStarted: SharingStarted
 ): MicroFeatureViewModel {
 
     @AssistedFactory

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/di/RecentSearchesModule.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/di/RecentSearchesModule.kt
@@ -1,0 +1,31 @@
+package com.example.microfeaturecodelab.recentsearches.di
+
+import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
+import com.example.microfeaturecodelab.base.MicroFeatureFactory
+import com.example.microfeaturecodelab.base.MicroFeatureViewModel
+import com.example.microfeaturecodelab.di.ComponentTypeKey
+import com.example.microfeaturecodelab.premiumApplicant.presentation.PremiumApplicantComposer
+import com.example.microfeaturecodelab.premiumApplicant.presentation.PremiumApplicantViewModel
+import com.example.microfeaturecodelab.recentsearches.presentation.RecentSearchesListComposer
+import com.example.microfeaturecodelab.recentsearches.presentation.RecentSearchesViewModel
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.multibindings.IntoMap
+
+@Module
+@InstallIn(ViewModelComponent::class)
+interface ComponentComposerModule {
+
+    @Binds
+    @IntoMap
+    @ComponentTypeKey("recentSearches")
+    fun bindRecentSearchesComposer(composer: RecentSearchesListComposer): AbstractMicroFeatureComposer<out MicroFeatureViewModel>
+
+    @Binds
+    @IntoMap
+    @ComponentTypeKey("recentSearches")
+    fun bindRecentSearchesViewModel(viewmodelFactory: RecentSearchesViewModel.Factory): MicroFeatureFactory<out MicroFeatureViewModel>
+
+}

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/domain/RecentSearchesUseCase.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/domain/RecentSearchesUseCase.kt
@@ -1,0 +1,41 @@
+package com.example.microfeaturecodelab.recentsearches.domain
+
+import com.example.microfeaturecodelab.recentsearches.presentation.RecentSearchItem
+import com.example.microfeaturecodelab.recentsearches.presentation.RecentSearchesList
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+class RecentSearchesUseCase @Inject constructor() {
+
+    // Fetch recent searches
+    fun getRecentSearches(param: RecentSearchParameter) = flowOf(
+        RecentSearchesList(
+            listOf(
+                RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
+                RecentSearchItem("rc2", "Software Engineer", "45 new", "India"),
+                RecentSearchItem("rc3", "Staff Engineer", "21 new", "India : Remote"),
+                RecentSearchItem("rc4", "Product Manager", "10 new", "London, UK"),
+                RecentSearchItem("rc5", "Data Scientist", "", "Berlin, Germany"),
+                RecentSearchItem("rc6", "Backend Engineer", "15 new", "Toronto, Canada"),
+                RecentSearchItem("rc7", "Frontend Engineer", "12 new", "Austin, TX"),
+                RecentSearchItem("rc8", "DevOps Engineer", "33 new", "Sydney, Australia"),
+                RecentSearchItem("rc9", "Machine Learning Engineer", "", "New York, NY"),
+                RecentSearchItem("rc10", "UI/UX Designer", "18 new", "Los Angeles, CA"),
+                RecentSearchItem("rc11", "Full Stack Developer", "20 new", "Paris, France"),
+                RecentSearchItem("rc12", "Cloud Architect", "", "Dublin, Ireland"),
+                RecentSearchItem("rc13", "QA Engineer", "5 new", "Singapore"),
+                RecentSearchItem("rc14", "Security Analyst", "", "Tokyo, Japan"),
+                RecentSearchItem("rc15", "Technical Writer", "8 new", "Remote")
+            )
+        )
+    )
+
+}
+
+data class RecentSearchParameter(
+    val pageSize: Int
+) {
+    companion object {
+        val DEFAULT = RecentSearchParameter(pageSize = 15)
+    }
+}

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesListComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesListComposer.kt
@@ -4,11 +4,13 @@ import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,21 +36,31 @@ class RecentSearchesListComposer @Inject constructor() :
         modifier: Modifier,
         onAction: (Any) -> Unit,
     ) {
-        // Since we cannot use viewmodel.uiState.collectAsStateWithLifecycle() in
-        // non composable function LazyListScope.content()
+        // FIXME: We cannot use viewmodel.uiState.collectAsStateWithLifecycle() in
+        // non composable function LazyListScope.content() and
+        // items api require size or list reference
         lifecycle.lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { data ->
-                    items(
-                        items = data.items,
-                        key = { it.id },
-                        itemContent = { recentSearches ->
-                            RecentSearch(
-                                recentSearchItem = recentSearches,
-                                modifier = modifier
+                    if (data.items.isEmpty()) {
+                        item {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp), // Size of the loader
+                                color = MaterialTheme.colorScheme.tertiary // Loader color
                             )
                         }
-                    )
+                    } else {
+                        items(
+                            items = data.items,
+                            key = { it.id },
+                            itemContent = { recentSearches ->
+                                RecentSearch(
+                                    recentSearchItem = recentSearches,
+                                    modifier = modifier
+                                )
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesListComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesListComposer.kt
@@ -1,0 +1,69 @@
+package com.example.microfeaturecodelab.recentsearches.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
+import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
+import javax.inject.Inject
+
+class RecentSearchesListComposer @Inject constructor() :
+    AbstractMicroFeatureComposer<RecentSearchesViewModel>() {
+    override fun LazyListScope.content(
+        viewModel: RecentSearchesViewModel,
+        config: ComponentConfig,
+        modifier: Modifier,
+        onAction: (Any) -> Unit
+    ) {
+        // @TODO ISSUE #2
+        // How to use viewmodel.uiState.collectAsStateWithLifecycle() in
+        // non composable function LazyListScope.content()
+        val jobItems by viewModel.uiState
+        items(
+            items = jobItems.items,
+            key = { it.id },
+            itemContent = { data ->
+                RecentSearch(
+                    recentSearchItem = data,
+                    modifier = modifier
+                )
+            }
+        )
+    }
+
+    @Composable
+    fun RecentSearch(
+        recentSearchItem: RecentSearchItem,
+        modifier: Modifier = Modifier,
+    ) {
+        Card(
+            shape = RoundedCornerShape(8.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+            modifier = modifier
+                .padding(vertical = 4.dp),
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text = recentSearchItem.positionName,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Text(text = recentSearchItem.location, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesListComposer.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesListComposer.kt
@@ -1,5 +1,6 @@
 package com.example.microfeaturecodelab.recentsearches.presentation
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,11 +12,17 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.microfeaturecodelab.base.AbstractMicroFeatureComposer
 import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.ComponentConfig
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class RecentSearchesListComposer @Inject constructor() :
@@ -23,23 +30,28 @@ class RecentSearchesListComposer @Inject constructor() :
     override fun LazyListScope.content(
         viewModel: RecentSearchesViewModel,
         config: ComponentConfig,
+        lifecycle: LifecycleOwner,
         modifier: Modifier,
-        onAction: (Any) -> Unit
+        onAction: (Any) -> Unit,
     ) {
-        // @TODO ISSUE #2
-        // How to use viewmodel.uiState.collectAsStateWithLifecycle() in
+        // Since we cannot use viewmodel.uiState.collectAsStateWithLifecycle() in
         // non composable function LazyListScope.content()
-        val jobItems by viewModel.uiState
-        items(
-            items = jobItems.items,
-            key = { it.id },
-            itemContent = { data ->
-                RecentSearch(
-                    recentSearchItem = data,
-                    modifier = modifier
-                )
+        lifecycle.lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { data ->
+                    items(
+                        items = data.items,
+                        key = { it.id },
+                        itemContent = { recentSearches ->
+                            RecentSearch(
+                                recentSearchItem = recentSearches,
+                                modifier = modifier
+                            )
+                        }
+                    )
+                }
             }
-        )
+        }
     }
 
     @Composable
@@ -47,6 +59,14 @@ class RecentSearchesListComposer @Inject constructor() :
         recentSearchItem: RecentSearchItem,
         modifier: Modifier = Modifier,
     ) {
+        LaunchedEffect(recentSearchItem) {
+            Log.d("RecentSearchesListComposer", "Launched effect: ${recentSearchItem.id}")
+        }
+        DisposableEffect(recentSearchItem) {
+            onDispose {
+                Log.d("RecentSearchesListComposer", "onDispose: ${recentSearchItem.id}")
+            }
+        }
         Card(
             shape = RoundedCornerShape(8.dp),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesViewModel.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.compose.runtime.Immutable
 import com.example.microfeaturecodelab.base.MicroFeatureFactory
 import com.example.microfeaturecodelab.base.MicroFeatureViewModel
+import com.example.microfeaturecodelab.personalisedjob.presentation.featureconfig.FetchStrategy
+import com.example.microfeaturecodelab.recentsearches.domain.RecentSearchParameter
+import com.example.microfeaturecodelab.recentsearches.domain.RecentSearchesUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -15,46 +18,28 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 
 class RecentSearchesViewModel @AssistedInject constructor(
-    @Assisted val coroutineScope: CoroutineScope
+    private val useCase: RecentSearchesUseCase,
+    @Assisted val coroutineScope: CoroutineScope,
+    @Assisted val sharingStarted: SharingStarted
 ) : MicroFeatureViewModel {
 
-    private val inputFlow = MutableStateFlow("1")
+    private val inputFlow = MutableStateFlow(RecentSearchParameter.DEFAULT)
 
     // @TODO how to consume state flow in non compose scope renderer
     @OptIn(ExperimentalCoroutinesApi::class)
     val uiState: StateFlow<RecentSearchesList> = inputFlow.flatMapLatest { input ->
         Log.d("RecentSearchesViewModel", "Fetching recent searches ${this.hashCode()}")
-        delay(1000L)
-        flowOf(
-            RecentSearchesList(
-                listOf(
-                    RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
-                    RecentSearchItem("rc2", "Software Engineer", "45 new", "India"),
-                    RecentSearchItem("rc3", "Staff Engineer", "21 new", "India : Remote"),
-                    RecentSearchItem("rc4", "Product Manager", "10 new", "London, UK"),
-                    RecentSearchItem("rc5", "Data Scientist", "", "Berlin, Germany"),
-                    RecentSearchItem("rc6", "Backend Engineer", "15 new", "Toronto, Canada"),
-                    RecentSearchItem("rc7", "Frontend Engineer", "12 new", "Austin, TX"),
-                    RecentSearchItem("rc8", "DevOps Engineer", "33 new", "Sydney, Australia"),
-                    RecentSearchItem("rc9", "Machine Learning Engineer", "", "New York, NY"),
-                    RecentSearchItem("rc10", "UI/UX Designer", "18 new", "Los Angeles, CA"),
-                    RecentSearchItem("rc11", "Full Stack Developer", "20 new", "Paris, France"),
-                    RecentSearchItem("rc12", "Cloud Architect", "", "Dublin, Ireland"),
-                    RecentSearchItem("rc13", "QA Engineer", "5 new", "Singapore"),
-                    RecentSearchItem("rc14", "Security Analyst", "", "Tokyo, Japan"),
-                    RecentSearchItem("rc15", "Technical Writer", "8 new", "Remote")
-                )
-            )
-        ).catch {
+        delay(5000L)
+        useCase.getRecentSearches(input)
+        .catch {
             Log.d("RecentSearchesViewModel", "Failed to fetch recent searches")
         }
     }.stateIn(
         scope = coroutineScope,
-        started = SharingStarted.WhileSubscribed(5000L),
+        started = sharingStarted,
         initialValue = RecentSearchesList(emptyList())
     )
 

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesViewModel.kt
@@ -2,7 +2,6 @@ package com.example.microfeaturecodelab.recentsearches.presentation
 
 import android.util.Log
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.mutableStateOf
 import com.example.microfeaturecodelab.base.MicroFeatureFactory
 import com.example.microfeaturecodelab.base.MicroFeatureViewModel
 import dagger.assisted.Assisted
@@ -25,38 +24,39 @@ class RecentSearchesViewModel @AssistedInject constructor(
 
     private val inputFlow = MutableStateFlow("1")
 
-    // Replace this later with use case backed data
-    val uiState = mutableStateOf(
-        RecentSearchesList(
-            listOf(
-                RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
-                RecentSearchItem("rc2", "Software Engineer", "", "India"),
-                RecentSearchItem("rc3", "Staff Engineer", "", "India : Remote"),
-            )
-        )
-    )
-
     // @TODO how to consume state flow in non compose scope renderer
-//    @OptIn(ExperimentalCoroutinesApi::class)
-//    val uiState: StateFlow<RecentSearchesList> = inputFlow.flatMapLatest { input ->
-//        Log.d("RecentSearchesViewModel", "Fetching recent searches ${this.hashCode()}")
-//        delay(1000L)
-//        flowOf(
-//            RecentSearchesList(
-//                listOf(
-//                    RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
-//                    RecentSearchItem("rc2", "Software Engineer", "", "India"),
-//                    RecentSearchItem("rc3", "Staff Engineer", "", "India : Remote"),
-//                )
-//            )
-//        ).catch {
-//            Log.d("RecentSearchesViewModel", "Failed to fetch recent searches")
-//        }
-//    }.stateIn(
-//        scope = coroutineScope,
-//        started = SharingStarted.WhileSubscribed(5000L),
-//        initialValue = RecentSearchesList(emptyList())
-//    )
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<RecentSearchesList> = inputFlow.flatMapLatest { input ->
+        Log.d("RecentSearchesViewModel", "Fetching recent searches ${this.hashCode()}")
+        delay(1000L)
+        flowOf(
+            RecentSearchesList(
+                listOf(
+                    RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
+                    RecentSearchItem("rc2", "Software Engineer", "45 new", "India"),
+                    RecentSearchItem("rc3", "Staff Engineer", "21 new", "India : Remote"),
+                    RecentSearchItem("rc4", "Product Manager", "10 new", "London, UK"),
+                    RecentSearchItem("rc5", "Data Scientist", "", "Berlin, Germany"),
+                    RecentSearchItem("rc6", "Backend Engineer", "15 new", "Toronto, Canada"),
+                    RecentSearchItem("rc7", "Frontend Engineer", "12 new", "Austin, TX"),
+                    RecentSearchItem("rc8", "DevOps Engineer", "33 new", "Sydney, Australia"),
+                    RecentSearchItem("rc9", "Machine Learning Engineer", "", "New York, NY"),
+                    RecentSearchItem("rc10", "UI/UX Designer", "18 new", "Los Angeles, CA"),
+                    RecentSearchItem("rc11", "Full Stack Developer", "20 new", "Paris, France"),
+                    RecentSearchItem("rc12", "Cloud Architect", "", "Dublin, Ireland"),
+                    RecentSearchItem("rc13", "QA Engineer", "5 new", "Singapore"),
+                    RecentSearchItem("rc14", "Security Analyst", "", "Tokyo, Japan"),
+                    RecentSearchItem("rc15", "Technical Writer", "8 new", "Remote")
+                )
+            )
+        ).catch {
+            Log.d("RecentSearchesViewModel", "Failed to fetch recent searches")
+        }
+    }.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5000L),
+        initialValue = RecentSearchesList(emptyList())
+    )
 
     @AssistedFactory
     interface Factory : MicroFeatureFactory<RecentSearchesViewModel>

--- a/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesViewModel.kt
+++ b/app/src/main/java/com/example/microfeaturecodelab/recentsearches/presentation/RecentSearchesViewModel.kt
@@ -1,0 +1,77 @@
+package com.example.microfeaturecodelab.recentsearches.presentation
+
+import android.util.Log
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.mutableStateOf
+import com.example.microfeaturecodelab.base.MicroFeatureFactory
+import com.example.microfeaturecodelab.base.MicroFeatureViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+
+class RecentSearchesViewModel @AssistedInject constructor(
+    @Assisted val coroutineScope: CoroutineScope
+) : MicroFeatureViewModel {
+
+    private val inputFlow = MutableStateFlow("1")
+
+    // Replace this later with use case backed data
+    val uiState = mutableStateOf(
+        RecentSearchesList(
+            listOf(
+                RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
+                RecentSearchItem("rc2", "Software Engineer", "", "India"),
+                RecentSearchItem("rc3", "Staff Engineer", "", "India : Remote"),
+            )
+        )
+    )
+
+    // @TODO how to consume state flow in non compose scope renderer
+//    @OptIn(ExperimentalCoroutinesApi::class)
+//    val uiState: StateFlow<RecentSearchesList> = inputFlow.flatMapLatest { input ->
+//        Log.d("RecentSearchesViewModel", "Fetching recent searches ${this.hashCode()}")
+//        delay(1000L)
+//        flowOf(
+//            RecentSearchesList(
+//                listOf(
+//                    RecentSearchItem("rc1", "Android Engineer", "69 new", "San Francisco, CA"),
+//                    RecentSearchItem("rc2", "Software Engineer", "", "India"),
+//                    RecentSearchItem("rc3", "Staff Engineer", "", "India : Remote"),
+//                )
+//            )
+//        ).catch {
+//            Log.d("RecentSearchesViewModel", "Failed to fetch recent searches")
+//        }
+//    }.stateIn(
+//        scope = coroutineScope,
+//        started = SharingStarted.WhileSubscribed(5000L),
+//        initialValue = RecentSearchesList(emptyList())
+//    )
+
+    @AssistedFactory
+    interface Factory : MicroFeatureFactory<RecentSearchesViewModel>
+
+}
+
+@Immutable
+data class RecentSearchesList(
+    val items: List<RecentSearchItem>
+)
+
+data class RecentSearchItem(
+    val id: String,
+    val positionName: String,
+    val badge: String,
+    val location: String,
+    val jobType: String = "Full-time",
+)


### PR DESCRIPTION
### Two issues remaining:


### Collect data in lazylist non composable scope from ViewModel in RecentSearchesListComposer
```
 override fun LazyListScope.content(
        viewModel: RecentSearchesViewModel,
        config: ComponentConfig,
        modifier: Modifier,
        onAction: (Any) -> Unit
    ) {
        // @TODO ISSUE #2
        // How to use viewmodel.uiState.collectAsStateWithLifecycle() in
        // non composable function LazyListScope.content()
        val jobItems by viewModel.uiState
        items(
            items = jobItems.items,
            key = { it.id },
            itemContent = { data ->
                RecentSearch(
                    recentSearchItem = data,
                    modifier = modifier
                )
            }
        )
    }
```

### Sealed class uistate recomposing whole lazy column in PersonalisedJobViewModel
```
val uiState: StateFlow<UiState> = inputFlow.flatMapLatest { input ->
        Log.d("PersonalisedJobViewModel", "Fetching jobs with input: ${this.hashCode()}")
        useCase.fetch(input).map {
            UiState.Success(it.toUiModel())
        }.catch {
            UiState.Error("Failed to fetch jobs")
        }
    }.stateIn(
        scope = coroutineScope,
        started = SharingStarted.WhileSubscribed(5000L),
        initialValue = UiState.Loading
    )
```